### PR TITLE
Update range operator

### DIFF
--- a/Skiptaculous/PlayScene.swift
+++ b/Skiptaculous/PlayScene.swift
@@ -105,7 +105,7 @@ class PlayScene: SKScene, SKPhysicsContactDelegate {
     }
     
     func random() -> UInt32 {
-        var range = UInt32(50)..UInt32(200)
+        var range = UInt32(50)..<UInt32(200)
         return range.startIndex + arc4random_uniform(range.endIndex - range.startIndex + 1)
     }
     


### PR DESCRIPTION
One of the range operators needed to be updated from the old Swift syntax to the new range syntax. 
![](http://media.giphy.com/media/dRsv3UDF4KZ6E/giphy.gif)
